### PR TITLE
Set annotation on data-* property

### DIFF
--- a/src/annotator.imgselect.js
+++ b/src/annotator.imgselect.js
@@ -133,7 +133,7 @@ function annotatorImageSelect(options) {
        hl.attr('data-annotation-id', annotation.id);
      }
      // Save the annotation data on each highlighter element.
-     hl.data('annotation', annotation);
+     hl.attr('data-annotation', JSON.stringify(annotation));
 
      // add highlight to img parent element
      // NOTE: this relies on readux style/layout for correct placement


### PR DESCRIPTION
Using `.data()` proves problematic as annotator.js is unable to retrieve the data. Encoding annotation to JSON and storing in `data-annotation` allows annotator.js to retrieve the annotation.

This is in reference to #1. The demo now appears to work as expected.

<img width="385" alt="screenshot" src="https://cloud.githubusercontent.com/assets/897290/17600007/e4a5d8f0-5fbe-11e6-8201-371adf1701f0.png">
## Reasoning

Looking into `annotator.js`, I can see that `jQuery` is extended/augmented with `dataAttr`:

``` js
function dataAttr( elem, key, data ) {
    // If nothing was found internally, try to fetch any
    // data from the HTML5 data-* attribute
    if ( data === undefined && elem.nodeType === 1 ) {

        var name = "data-" + key.replace( rmultiDash, "-$1" ).toLowerCase();

        data = elem.getAttribute( name );

        if ( typeof data === "string" ) {
            try {
                data = data === "true" ? true :
                    data === "false" ? false :
                    data === "null" ? null :
                    // Only convert to a number if it doesn't change the string
                    +data + "" === data ? +data :
                    rbrace.test( data ) ? jQuery.parseJSON( data ) :
                    data;
            } catch( e ) {}

            // Make sure we set the data so it isn't changed later
            jQuery.data( elem, key, data );

        } else {
            data = undefined;
        }
    }

    return data;
}

// ...

jQuery.fn.extend({
    data: function( key, value ) {
        var i, name, data,
            elem = this[0],
            attrs = elem && elem.attributes;

        // Special expections of .data basically thwart jQuery.access,
        // so implement the relevant behavior ourselves

        // Gets all values
        if ( key === undefined ) {
            if ( this.length ) {
                data = jQuery.data( elem );

                if ( elem.nodeType === 1 && !jQuery._data( elem, "parsedAttrs" ) ) {
                    i = attrs.length;
                    while ( i-- ) {

                        // Support: IE11+
                        // The attrs elements can be null (#14894)
                        if ( attrs[ i ] ) {
                            name = attrs[ i ].name;
                            if ( name.indexOf( "data-" ) === 0 ) {
                                name = jQuery.camelCase( name.slice(5) );
                                dataAttr( elem, name, data[ name ] );
                            }
                        }
                    }
                    jQuery._data( elem, "parsedAttrs", true );
                }
            }

            return data;
        }
        // ...
    }
    // ...
},
```

You can see that it tries just about everything to coerse `data-*` into usable data, including parsing it as JSON (the `rbrace.test( data ) ? jQuery.parseJSON( data )`).
