### PR TITLE
BUGFIX: Canceling annotation was not deleting the selected area. The …

### DIFF
--- a/src/annotator.imgselect.js
+++ b/src/annotator.imgselect.js
@@ -28,8 +28,8 @@ function annotatorImageSelect(options) {
   var imgselect_utils = {
     // image area inital setup
     selectionSetup: function() {
-      $(document)
-        .on('click.imgselection','.imgareaselect-outer', '.annotator-cancel', function(evt) {
+      $('click.imgselection .imgareaselect-outer .annotator-cancel')
+        .on('click', function(e) {
           $(".tmp-img-selection").remove();
         });
       // escape key exits editor, so should also clear temporary selection


### PR DESCRIPTION
When drawing a box around an area of the image. If a user clicks on the pen to start adding an annotation but then hits cancel the area won't get deleted.

Please check the attached GIF to replicate the issue

![issue](https://cloud.githubusercontent.com/assets/9203175/23718626/70d2e8b0-03f5-11e7-96ee-544ede8d5538.gif)
